### PR TITLE
Add action match needed for _cat/indices request

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugin/readonlyrest/requestcontext/RCUtils.java
+++ b/core/src/main/java/org/elasticsearch/plugin/readonlyrest/requestcontext/RCUtils.java
@@ -45,6 +45,7 @@ public class RCUtils {
       "indices:admin/refresh*",
       "indices:admin/types/exists",
       "indices:admin/validate/*",
+      "indices:monitor/*",
       "indices:data/read/*"
   ));
 


### PR DESCRIPTION
This match is useful for Read-only configuration that includes reading list if indices